### PR TITLE
Add syntax highlighting to Examples.

### DIFF
--- a/content/pages/example.rst
+++ b/content/pages/example.rst
@@ -9,7 +9,7 @@ stored in variables, passed to and returned from functions, just like any
 other first class construct. Even so, we still have to start with
 "Hello world":
 
-::
+.. code-block:: idris
 
     main : IO ()
     main = putStrLn "Hello, Idris world"
@@ -19,7 +19,7 @@ is the (free) first chapter of
 `Type Driven Development with Idris <https://www.manning.com/books/type-driven-development-with-idris>`_.
 Briefly, it means you can write functions to calculate types:
 
-::
+.. code-block:: idris
 
     IntOrString : (isInt : Bool) -> Type
     IntOrString True = Int
@@ -29,7 +29,7 @@ Briefly, it means you can write functions to calculate types:
 The following function either converts an ``Int`` to a ``String``, or
 reverses the ``String``:
 
-::
+.. code-block:: idris
 
     showOrReverse : (isInt : Bool) -> IntOrString isInt -> String
     showOrReverse True x = show x
@@ -40,7 +40,7 @@ to ``printf``-like functions (full details omitted here, but you can
 see it in the `tests <https://github.com/edwinb/Idris2/blob/master/tests/typedd-book/chapter06/Printf.idr>`_, where
 the example is taken from the Type Driven Development book):
 
-::
+.. code-block:: idris
 
     printf : (format : String) -> PrintfType format
 
@@ -48,7 +48,7 @@ Idris data types are declared using a similar syntax to Haskell data types. For
 example, natural numbers, an option type and lists are declared in the standard
 library:
 
-::
+.. code-block:: idris
 
     data Nat     = Z       | S Nat
     data Maybe a = Nothing | Just a
@@ -57,7 +57,7 @@ library:
 Functions are implemented by pattern matching. For example, addition on natural
 numbers can be deﬁned as follows, again taken from the standard library:
 
-::
+.. code-block:: idris
 
     (+) : Nat -> Nat -> Nat
     Z     + y = y
@@ -74,7 +74,7 @@ which are lists which carry their size in the type. They are declared as
 follows in the standard library, by giving explicit types for each of the
 constructors:
 
-::
+.. code-block:: idris
 
     data Vect : Nat -> Type -> Type where
         Nil  : Vect Z a
@@ -85,7 +85,7 @@ the type how the function affects the size of the vectors. For example,
 if we append two vectors, the length of the result is the sum of the
 lengths of the inputs:
 
-::
+.. code-block:: idris
 
     app : Vect n a -> Vect m a -> Vect (n + m) a
     app Nil       ys = ys

--- a/content/posts/idris2-0-3-0-released.rst
+++ b/content/posts/idris2-0-3-0-released.rst
@@ -37,19 +37,25 @@ Language and compiler changes:
   linear versions of functions as special cases. (Though note that the 1
   multiplicity is still considered experimental, so hopefully this will change
   for the better in the future!)
-* Added new syntax for named applications of explicit arguments::
+* Added new syntax for named applications of explicit arguments
 
-     f {x [= t], x [= t], ...}
-     f {x [= t], x [= t], ..., _}
+  .. code-block:: idris
 
-* Added syntax for binding all explicit arguments (in the left hand side)::
+      f {x [= t], x [= t], ...}
+      f {x [= t], x [= t], ..., _}
 
-     f {}
+* Added syntax for binding all explicit arguments (in the left hand side)
+
+  .. code-block:: idris
+
+      f {}
 
 * Added new syntax for record updates (without the need for the ``record``
-  keyword)::
+  keyword)
 
-     {x := t, x $= t, ...}
+  .. code-block:: idris
+
+      {x := t, x $= t, ...}
 
 * Local implementations of interfaces (in ``let`` or ``where`` blocks) now work,
   along with ``%hint`` annotations on local definitions, meaning that local

--- a/notmyidea-cms/static/css/pygment.css
+++ b/notmyidea-cms/static/css/pygment.css
@@ -1,205 +1,72 @@
-.hll {
-background-color:#FFFFCC;
-}
-.c {
-color:#408090;
-font-style:italic;
-}
-.err {
-border:1px solid #FF0000;
-}
-.k {
-color:#007020;
-font-weight:bold;
-}
-.o {
-color:#666666;
-}
-.cm {
-color:#408090;
-font-style:italic;
-}
-.cp {
-color:#007020;
-}
-.c1 {
-color:#408090;
-font-style:italic;
-}
-.cs {
-background-color:#FFF0F0;
-color:#408090;
-}
-.gd {
-color:#A00000;
-}
-.ge {
-font-style:italic;
-}
-.gr {
-color:#FF0000;
-}
-.gh {
-color:#000080;
-font-weight:bold;
-}
-.gi {
-color:#00A000;
-}
-.go {
-color:#303030;
-}
-.gp {
-color:#C65D09;
-font-weight:bold;
-}
-.gs {
-font-weight:bold;
-}
-.gu {
-color:#800080;
-font-weight:bold;
-}
-.gt {
-color:#0040D0;
-}
-.kc {
-color:#007020;
-font-weight:bold;
-}
-.kd {
-color:#007020;
-font-weight:bold;
-}
-.kn {
-color:#007020;
-font-weight:bold;
-}
-.kp {
-color:#007020;
-}
-.kr {
-color:#007020;
-font-weight:bold;
-}
-.kt {
-color:#902000;
-}
-.m {
-color:#208050;
-}
-.s {
-color:#4070A0;
-}
-.na {
-color:#4070A0;
-}
-.nb {
-color:#007020;
-}
-.nc {
-color:#0E84B5;
-font-weight:bold;
-}
-.no {
-color:#60ADD5;
-}
-.nd {
-color:#555555;
-font-weight:bold;
-}
-.ni {
-color:#D55537;
-font-weight:bold;
-}
-.ne {
-color:#007020;
-}
-.nf {
-color:#06287E;
-}
-.nl {
-color:#002070;
-font-weight:bold;
-}
-.nn {
-color:#0E84B5;
-font-weight:bold;
-}
-.nt {
-color:#062873;
-font-weight:bold;
-}
-.nv {
-color:#BB60D5;
-}
-.ow {
-color:#007020;
-font-weight:bold;
-}
-.w {
-color:#BBBBBB;
-}
-.mf {
-color:#208050;
-}
-.mh {
-color:#208050;
-}
-.mi {
-color:#208050;
-}
-.mo {
-color:#208050;
-}
-.sb {
-color:#4070A0;
-}
-.sc {
-color:#4070A0;
-}
-.sd {
-color:#4070A0;
-font-style:italic;
-}
-.s2 {
-color:#4070A0;
-}
-.se {
-color:#4070A0;
-font-weight:bold;
-}
-.sh {
-color:#4070A0;
-}
-.si {
-color:#70A0D0;
-font-style:italic;
-}
-.sx {
-color:#C65D09;
-}
-.sr {
-color:#235388;
-}
-.s1 {
-color:#4070A0;
-}
-.ss {
-color:#517918;
-}
-.bp {
-color:#007020;
-}
-.vc {
-color:#BB60D5;
-}
-.vg {
-color:#BB60D5;
-}
-.vi {
-color:#BB60D5;
-}
-.il {
-color:#208050;
-}
+.highlight .hll { background-color: #49483e }
+.highlight  { background: #272822; color: #f8f8f2 }
+.highlight .c { color: #75715e } /* Comment */
+.highlight .err { color: #960050; background-color: #1e0010 } /* Error */
+.highlight .k { color: #66d9ef } /* Keyword */
+.highlight .l { color: #ae81ff } /* Literal */
+.highlight .n { color: #f8f8f2 } /* Name */
+.highlight .o { color: #f92672 } /* Operator */
+.highlight .p { color: #f8f8f2 } /* Punctuation */
+.highlight .ch { color: #75715e } /* Comment.Hashbang */
+.highlight .cm { color: #75715e } /* Comment.Multiline */
+.highlight .cp { color: #75715e } /* Comment.Preproc */
+.highlight .cpf { color: #75715e } /* Comment.PreprocFile */
+.highlight .c1 { color: #75715e } /* Comment.Single */
+.highlight .cs { color: #75715e } /* Comment.Special */
+.highlight .gd { color: #f92672 } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gi { color: #a6e22e } /* Generic.Inserted */
+.highlight .go { color: #66d9ef } /* Generic.Output */
+.highlight .gp { color: #f92672; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #75715e } /* Generic.Subheading */
+.highlight .kc { color: #66d9ef } /* Keyword.Constant */
+.highlight .kd { color: #66d9ef } /* Keyword.Declaration */
+.highlight .kn { color: #f92672 } /* Keyword.Namespace */
+.highlight .kp { color: #66d9ef } /* Keyword.Pseudo */
+.highlight .kr { color: #66d9ef } /* Keyword.Reserved */
+.highlight .kt { color: #66d9ef } /* Keyword.Type */
+.highlight .ld { color: #e6db74 } /* Literal.Date */
+.highlight .m { color: #ae81ff } /* Literal.Number */
+.highlight .s { color: #e6db74 } /* Literal.String */
+.highlight .na { color: #a6e22e } /* Name.Attribute */
+.highlight .nb { color: #f8f8f2 } /* Name.Builtin */
+.highlight .nc { color: #a6e22e } /* Name.Class */
+.highlight .no { color: #66d9ef } /* Name.Constant */
+.highlight .nd { color: #a6e22e } /* Name.Decorator */
+.highlight .ni { color: #f8f8f2 } /* Name.Entity */
+.highlight .ne { color: #a6e22e } /* Name.Exception */
+.highlight .nf { color: #a6e22e } /* Name.Function */
+.highlight .nl { color: #f8f8f2 } /* Name.Label */
+.highlight .nn { color: #f8f8f2 } /* Name.Namespace */
+.highlight .nx { color: #a6e22e } /* Name.Other */
+.highlight .py { color: #f8f8f2 } /* Name.Property */
+.highlight .nt { color: #f92672 } /* Name.Tag */
+.highlight .nv { color: #f8f8f2 } /* Name.Variable */
+.highlight .ow { color: #f92672 } /* Operator.Word */
+.highlight .w { color: #f8f8f2 } /* Text.Whitespace */
+.highlight .mb { color: #ae81ff } /* Literal.Number.Bin */
+.highlight .mf { color: #ae81ff } /* Literal.Number.Float */
+.highlight .mh { color: #ae81ff } /* Literal.Number.Hex */
+.highlight .mi { color: #ae81ff } /* Literal.Number.Integer */
+.highlight .mo { color: #ae81ff } /* Literal.Number.Oct */
+.highlight .sa { color: #e6db74 } /* Literal.String.Affix */
+.highlight .sb { color: #e6db74 } /* Literal.String.Backtick */
+.highlight .sc { color: #e6db74 } /* Literal.String.Char */
+.highlight .dl { color: #e6db74 } /* Literal.String.Delimiter */
+.highlight .sd { color: #e6db74 } /* Literal.String.Doc */
+.highlight .s2 { color: #e6db74 } /* Literal.String.Double */
+.highlight .se { color: #ae81ff } /* Literal.String.Escape */
+.highlight .sh { color: #e6db74 } /* Literal.String.Heredoc */
+.highlight .si { color: #e6db74 } /* Literal.String.Interpol */
+.highlight .sx { color: #e6db74 } /* Literal.String.Other */
+.highlight .sr { color: #e6db74 } /* Literal.String.Regex */
+.highlight .s1 { color: #e6db74 } /* Literal.String.Single */
+.highlight .ss { color: #e6db74 } /* Literal.String.Symbol */
+.highlight .bp { color: #f8f8f2 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #a6e22e } /* Name.Function.Magic */
+.highlight .vc { color: #f8f8f2 } /* Name.Variable.Class */
+.highlight .vg { color: #f8f8f2 } /* Name.Variable.Global */
+.highlight .vi { color: #f8f8f2 } /* Name.Variable.Instance */
+.highlight .vm { color: #f8f8f2 } /* Name.Variable.Magic */
+.highlight .il { color: #ae81ff } /* Literal.Number.Integer.Long */


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/933300/118539611-ebb8fa80-b74f-11eb-87a6-48bbfab828f9.png)


The default colors from the template were ugly and hard to read, so I regenerated the CSS with

```
pygmentize -S monokai -f html -a .highlight > notmyidea-cms/static/css/pygment.css
```

according to https://docs.getpelican.com/en/4.6.0/faq.html#i-m-creating-my-own-theme-how-do-i-use-pygments-for-syntax-highlighting